### PR TITLE
Add initial code files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,7 +47,7 @@ BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterColon
 BreakStringLiterals: 'true'
 BreakConstructorInitializersBeforeComma: 'false'
-ColumnLimit: 0
+ColumnLimit: 100
 CompactNamespaces: 'false'
 ConstructorInitializerAllOnOneLineOrOnePerLine: 'false'
 ConstructorInitializerIndentWidth: 1
@@ -63,7 +63,6 @@ IndentPPDirectives: BeforeHash
 IndentWidth: 4
 IndentWrappedFunctionNames: 'true'
 KeepEmptyLinesAtTheStartOfBlocks: 'false'
-LineEnding: LF
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 PointerAlignment: Left

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,53 +1,21 @@
 Checks: >
-        -*,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,-misc-no-recursion,readability-identifier-naming
-        bugprone-argument-comment,
-        bugprone-assert-side-effect,
-        bugprone-branch-clone,
-        bugprone-copy-constructor-init,
-        bugprone-dangling-handle,
-        bugprone-dynamic-static-initializers,
-        bugprone-macro-parentheses,
-        bugprone-macro-repeated-side-effects,
-        bugprone-misplaced-widening-cast,
-        bugprone-move-forwarding-reference,
-        bugprone-multiple-statement-macro,
-        bugprone-suspicious-semicolon,
-        bugprone-swapped-arguments,
-        bugprone-terminating-continue,
-        bugprone-unused-raii,
-        bugprone-unused-return-value,
-        misc-redundant-expression,
-        misc-static-assert,
-        misc-unused-parameters,
-        misc-unused-using-decls,
-        modernize-use-bool-literals,
-        modernize-loop-convert,
-        modernize-make-unique,
-        modernize-raw-string-literal,
-        modernize-use-equals-default,
-        modernize-use-default-member-init,
-        modernize-use-emplace,
-        modernize-use-nullptr,
-        modernize-use-override,
-        modernize-use-using,
-        performance-for-range-copy,
-        performance-implicit-conversion-in-loop,
-        performance-inefficient-algorithm,
-        performance-inefficient-vector-operation,
-        performance-move-const-arg,
-        performance-no-automatic-move,
-        performance-trivially-destructible,
-        performance-unnecessary-copy-initialization,
-        performance-unnecessary-value-param,
-        readability-avoid-const-params-in-decls,
-        readability-const-return-type,
-        readability-container-size-empty,
-        readability-inconsistent-declaration-parameter-name,
-        readability-misleading-indentation,
-        readability-redundant-control-flow,
-        readability-simplify-boolean-expr,
-        readability-simplify-subscript-expr,
-        readability-use-anyofallof
+        -*,
+        clang-diagnostic-*,
+        clang-analyzer-optin.*,
+        llvm-*,
+        google-*,-google-readability-todo,-google-readability-braces-around-statements,
+        hicpp-*,-hicpp-braces-around-statements,-hicpp-use-emplace,
+        misc-*,-misc-no-recursion,
+        bugprone-*,
+        boost-*,
+        cert-*,
+        concurrency-*,
+        cppcoreguidelines-*,
+        modernize-*,-modernize-use-trailing-return-type,-modernize-use-emplace,
+        performance-*,
+        portability-*,
+        readability-*,
+        -readability-braces-around-statements,-readability-redundant-access-specifiers
 
 CheckOptions:
   - key:             readability-identifier-naming.AbstractClassCase
@@ -55,87 +23,87 @@ CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
   - key:             readability-identifier-naming.ClassConstantCase
-    value:           camelCase
+    value:           UPPER_CASE
   - key:             readability-identifier-naming.ClassMemberCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.ClassMethodCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.ConstantCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.ConstantMemberCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.ConstantParameterCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.ConstantPointerParameterCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.ConstexprFunctionCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.ConstexprMethodCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.ConstexprVariableCase
-    value:           camelCase
+    value:           UPPER_CASE
   - key:             readability-identifier-naming.EnumCase
     value:           CamelCase
   - key:             readability-identifier-naming.EnumConstantCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.FunctionCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.GetConfigPerFile
     value:           true
   - key:             readability-identifier-naming.GlobalConstantCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.GlobalConstantPointerCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.GlobalFunctionCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.GlobalPointerCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.GlobalVariableCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.IgnoreMainLikeFunctions
     value:           1
   - key:             readability-identifier-naming.InlineNamespaceCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.LocalConstantCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.LocalConstantPointerCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.LocalPointerCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.LocalVariableCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.MacroDefinitionCase
     value:           UPPER_CASE
   - key:             readability-identifier-naming.MemberCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.MethodCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.NamespaceCase
     value:           lower_case
   - key:             readability-identifier-naming.ParameterCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.ParameterPackCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.PointerParameterCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.PrivateMemberCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.PrivateMethodCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.ProtectedMemberCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.ProtectedMethodCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.PublicMemberCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.PublicMethodCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.ScopedEnumConstantCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.StaticConstantCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.StaticVariableCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.StructCase
     value:           CamelCase
   - key:             readability-identifier-naming.TemplateParameterCase
@@ -151,8 +119,8 @@ CheckOptions:
   - key:             readability-identifier-naming.UnionCase
     value:           CamelCase
   - key:             readability-identifier-naming.ValueTemplateParameterCase
-    value:           camelCase
+    value:           camelBack
   - key:             readability-identifier-naming.VariableCase
-    value:           camelCase
+    value:           lower_case
   - key:             readability-identifier-naming.VirtualMethodCase
-    value:           camelCase
+    value:           camelBack

--- a/.github/workflows/cpp-lint.yml
+++ b/.github/workflows/cpp-lint.yml
@@ -24,4 +24,5 @@ jobs:
       - name: Execute clang-tidy
         run: find . \( \( -path './build' -o -path '*/.*' \) -prune \) -o
           \( -type f -a \( -iname '*.cpp' -o -iname '*.h' \) \)
+          -exec echo "Linting '{}'..." \;
           -exec clang-tidy -p build {} +

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,9 +18,11 @@ jobs:
       - name: Execute clang-format
         run: find . \( -path '*/.*' -prune \) -o
           \( -type f -a \( -iname '*.cpp' -o -iname '*.h' \) \)
+          -exec echo "Format checking '{}'..." \;
           -exec clang-format --dry-run --Werror {} +
       # Check all cmake files; ignore files in hidden directories
       - name: Execute cmake-format
         run: find . \( -path '*/.*' -prune \) -o
           \( -type f -a -name 'CMakeLists.txt' \)
+          -exec echo "Format checking '{}'..." \;
           -exec cmake-format --check -- {} +

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 build/
+.cache/
+
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 set(OPTIMIZE_FLAGS "-O2")
 set(DEBUG_FLAGS "-g3")
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-set(CMAKE_CXX_EXTENSIONS YES)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_CXX_FLAGS
     "-fsanitize=undefined -pthread -ffast-math -Wall -Wextra -Wno-psabi -pedantic-errors"
@@ -30,3 +30,5 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${DEBUG_FLAGS} ${OPTIMIZE_FLAGS}")
 set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os")
 
 message(STATUS "Compiling in ${CMAKE_BUILD_TYPE} mode")
+
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(TARGET_NAME "flounder_game")
+
+add_executable(${TARGET_NAME} main.cpp)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,4 @@
+int main(int /*argc*/, char* /*argv*/[])
+{
+    return 0;
+}


### PR DESCRIPTION
Includes a basic cmake file and an empty main function.

Additionally, adapt the clang-format and clang-tidy configurations and set C++ standard to 20 while disallowing compiler extensions.