### PR TITLE
Add basic C++ CI

### DIFF
--- a/.github/workflows/cpp-build.yml
+++ b/.github/workflows/cpp-build.yml
@@ -1,0 +1,25 @@
+name: "C++ Build"
+description: "Use GCC to compile the C++ code"
+
+on: [push, pull_request]
+
+jobs:
+  format:
+    name: "gcc build"
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install dependencies
+      run: |
+          sudo apt-get update -y
+          sudo apt-get -y --no-install-recommends \
+            cmake='3.22.*' \
+            gcc-11='11.*' \
+            libboost-program-options-dev='1.74.*' \
+            libfmt-dev='8.*'
+    - name: Execute cmake
+      run: |
+        mkdir -pv build
+        cd build
+        cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+    - name: Execute make
+      run: make -j

--- a/.github/workflows/cpp-lint.yml
+++ b/.github/workflows/cpp-lint.yml
@@ -1,0 +1,25 @@
+name: "C++ Lint"
+description: "Use clang-tidy to lint C++ files"
+
+on: [push, pull_request]
+
+jobs:
+  format:
+    name: "clang-tidy"
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install dependencies
+      run: |
+          sudo apt-get update -y
+          sudo apt-get -y --no-install-recommends cmake='3.22.*' clang-tidy='14.*'
+    - name: Generate compile_commands.json
+      run: |
+        mkdir -pv build
+        cd build
+        cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+    # Check all source and header C++ files;
+    # ignore files in the build directory or in hidden directories
+    - name: Execute clang-tidy
+      run: find . \( \( -path './build' -o -path '*/.*' \) -prune \) -o \
+        \( -type f -a \( -iname '*.cpp' -o -iname '*.h' \) \) \
+        -exec clang-tidy -p build {} +

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,24 @@
+name: "C++/CMake Format"
+description: "Use clang-format and cmake-format to check formatting of C++ and cmake files"
+
+on: [push, pull_request]
+
+jobs:
+  format:
+    name: "clang-format/cmake-format"
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install dependencies
+      run: |
+          sudo apt-get update -y
+          sudo apt-get -y --no-install-recommends clang-format='14.*' cmake-format='0.6.*'
+    # Check all source and header C++ files; ignore files in hidden directories
+    - name: Execute clang-format
+      run: find . \( -path '*/.*' -prune \) -o \
+        \( -type f -a \( -iname '*.cpp' -o -iname '*.h' \) \) \
+        -exec clang-format --dry-run --Werror {} +
+    # Check all cmake files; ignore files in hidden directories
+    - name: Execute cmake-format
+      find . \( -path '*/.*' -prune \) -o \
+      \( -type f -a -name 'CMakeLists.txt' \) \
+      -exec cmake-format --check -- {} +


### PR DESCRIPTION
Introduce a CI for format checking, linting and building C++ code using the clang tools and CMake.