### PR TITLE
Add basic output manager

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -116,6 +116,9 @@ CheckOptions:
     value:           CamelCase
   - key:             readability-identifier-naming.TypeTemplateParameterCase
     value:           CamelCase
+# fix for clang-tidy v11, v12 and v14 when compiling with C++20
+  - key:             readability-identifier-naming.TypeTemplateParameterIgnoredRegexp
+    value: 'expr-type'
   - key:             readability-identifier-naming.UnionCase
     value:           CamelCase
   - key:             readability-identifier-naming.ValueTemplateParameterCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,7 @@ Checks: >
         -*,
         clang-diagnostic-*,
         clang-analyzer-optin.*,
-        llvm-*,
+        llvm-*,-llvm-header-guard,
         google-*,-google-readability-todo,-google-readability-braces-around-statements,
         hicpp-*,-hicpp-braces-around-statements,-hicpp-use-emplace,
         misc-*,-misc-no-recursion,

--- a/.github/workflows/cpp-lint.yml
+++ b/.github/workflows/cpp-lint.yml
@@ -13,7 +13,8 @@ jobs:
             sudo apt-get update -y
             sudo apt-get -y --no-install-recommends install \
               cmake='3.22.*' \
-              clang-tidy='1:14.*'
+              clang-tidy='1:14.*' \
+              libfmt-dev='8.*'
       - name: Generate compile_commands.json
         run: |
           mkdir -pv build

--- a/.github/workflows/cpp-lint.yml
+++ b/.github/workflows/cpp-lint.yml
@@ -26,4 +26,4 @@ jobs:
         run: find . \( \( -path './build' -o -path '*/.*' \) -prune \) -o
           \( -type f -a \( -iname '*.cpp' -o -iname '*.h' \) \)
           -exec echo "Linting '{}'..." \;
-          -exec clang-tidy -p build {} +
+          -exec clang-tidy -p build --warnings-as-errors='*' {} +

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+find_package(fmt 8.1.0 REQUIRED)
+
 set(TARGET_NAME "flounder_game")
 
 add_executable(${TARGET_NAME} main.cpp)
+target_link_libraries(${TARGET_NAME} PRIVATE fmt::fmt)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,25 @@
-int main(int /*argc*/, char* /*argv*/[])
+#include "output/output_manager.h"
+#include "output/cerr_output.h"
+#include "output/cout_output.h"
+#include "output/file_output.h"
+
+#include <chrono>
+#include <iostream>
+
+std::shared_ptr<flounder::OutputManager> createOutputManager()
 {
-    return 0;
+    auto output = std::make_shared<flounder::OutputManager>();
+    auto timestamp = std::chrono::system_clock::now().time_since_epoch().count();
+    output->addOutput(
+     std::make_unique<flounder::FileOutput>(std::to_string(timestamp) + "-flounder_log"));
+    output->addOutput(std::make_unique<flounder::CoutOutput>(), flounder::OutputLevel::user);
+    output->addOutput(std::make_unique<flounder::CerrOutput>(),
+     flounder::OutputLevel::fatal | flounder::OutputLevel::error | flounder::OutputLevel::warning |
+      flounder::OutputLevel::notice);
+    return output;
+}
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
+{
+    auto output = createOutputManager();
 }

--- a/src/output/cerr_output.h
+++ b/src/output/cerr_output.h
@@ -1,0 +1,28 @@
+#ifndef FLOUNDER_GAME_CERR_OUTPUT_H
+#define FLOUNDER_GAME_CERR_OUTPUT_H
+
+#include "output.h"
+
+#include <iostream>
+
+namespace flounder
+{
+class CerrOutput : public Output
+{
+public:
+    CerrOutput() = default;
+    std::ostream& stream() override
+    {
+        if(currentLevel() == OutputLevel::error || currentLevel() == OutputLevel::fatal)
+            std::cerr << OutputManipulator::RED;
+        else if(currentLevel() == OutputLevel::warning)
+            std::cerr << OutputManipulator::YELLOW;
+        else
+            std::cerr << OutputManipulator::RESET;
+        return std::cerr;
+    }
+};
+
+} // namespace flounder
+
+#endif // FLOUNDER_GAME_CERR_OUTPUT_H

--- a/src/output/cout_output.h
+++ b/src/output/cout_output.h
@@ -1,0 +1,25 @@
+#ifndef FLOUNDER_GAME_COUT_OUTPUT_H
+#define FLOUNDER_GAME_COUT_OUTPUT_H
+
+#include "output.h"
+
+#include <iostream>
+
+namespace flounder
+{
+class CoutOutput : public Output
+{
+public:
+    CoutOutput() = default;
+    ~CoutOutput() override { std::cout << std::flush; }
+    CoutOutput(const CoutOutput&) = default;
+    CoutOutput(CoutOutput&&) = default;
+    CoutOutput& operator=(const CoutOutput&) = default;
+    CoutOutput& operator=(CoutOutput&&) = default;
+
+    std::ostream& stream() override { return std::cout; }
+};
+
+} // namespace flounder
+
+#endif // FLOUNDER_GAME_COUT_OUTPUT_H

--- a/src/output/file_output.h
+++ b/src/output/file_output.h
@@ -1,0 +1,25 @@
+#ifndef FLOUNDER_GAME_FILE_OUTPUT_H
+#define FLOUNDER_GAME_FILE_OUTPUT_H
+
+#include "output.h"
+
+#include <fstream>
+
+namespace flounder
+{
+class FileOutput : public Output
+{
+public:
+    explicit FileOutput(const std::string& file_name, bool append = false) :
+     file_stream{file_name, (append) ? std::ios_base::app : std::ios_base::out}
+    {
+    }
+    std::ostream& stream() override { return file_stream; }
+
+private:
+    std::ofstream file_stream;
+};
+
+} // namespace flounder
+
+#endif // FLOUNDER_GAME_FILE_OUTPUT_H

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -1,0 +1,47 @@
+#ifndef FLOUNDER_GAME_OUTPUT_H
+#define FLOUNDER_GAME_OUTPUT_H
+
+#include "output_levels.h"
+
+#include <ostream>
+
+#include <fmt/format.h>
+
+namespace flounder
+{
+template<typename StreamType>
+class BaseOutput
+{
+public:
+    BaseOutput() = default;
+    virtual ~BaseOutput() = default;
+    BaseOutput(const BaseOutput&) = default;
+    BaseOutput(BaseOutput&&) noexcept = default;
+    BaseOutput& operator=(const BaseOutput&) = default;
+    BaseOutput& operator=(BaseOutput&&) noexcept = default;
+    virtual StreamType& stream() = 0;
+
+    template<typename Argument>
+    BaseOutput& operator<<(Argument&& argument)
+    {
+        stream() << argument;
+        return *this;
+    }
+
+    virtual BaseOutput& operator<<(OutputLevel level)
+    {
+        this->current_level = level;
+        return *this;
+    }
+
+protected:
+    OutputLevel currentLevel() { return current_level; }
+
+private:
+    OutputLevel current_level = OutputLevel::none;
+};
+
+using Output = BaseOutput<std::ostream>;
+} // namespace flounder
+
+#endif // FLOUNDER_GAME_OUTPUT_H

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -9,6 +9,16 @@
 
 namespace flounder
 {
+struct OutputManipulator
+{
+    static constexpr const char* RESET = "\033[49m";
+
+    static constexpr const char* RED = "\033[91m";
+    static constexpr const char* GREEN = "\033[92m";
+    static constexpr const char* YELLOW = "\033[93m";
+    static constexpr const char* BLUE = "\033[94m";
+};
+
 template<typename StreamType>
 class BaseOutput
 {

--- a/src/output/output_levels.h
+++ b/src/output/output_levels.h
@@ -1,0 +1,68 @@
+#ifndef FLOUNDER_GAME_OUTPUT_LEVELS_H
+#define FLOUNDER_GAME_OUTPUT_LEVELS_H
+
+#include <initializer_list>
+
+namespace flounder
+{
+enum class OutputLevel
+{
+    none = 0x00,
+    user = 0x01,
+    fatal = 0x02,
+    error = 0x04,
+    warning = 0x08,
+    notice = 0x10,
+    info = 0x20,
+    debug = 0x40,
+    all = 0xFF
+};
+
+class OutputLevels
+{
+public:
+    OutputLevels() : value{0} { }
+    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+    explicit(false) OutputLevels(OutputLevel level) : OutputLevels({level}) { }
+    OutputLevels(std::initializer_list<OutputLevel> levels) : value{0x00}
+    {
+        for(auto level : levels)
+            addLevel(level);
+    }
+
+    void addLevel(OutputLevel level) { this->value |= toInternal(level); }
+    void removeLevel(OutputLevel level) { this->value &= ~toInternal(level); }
+
+    [[nodiscard]] bool hasLevel(OutputLevel level) const
+    {
+        return (this->value & toInternal(level)) != 0x00;
+    }
+
+    OutputLevels operator|(OutputLevels rhs) const { return OutputLevels{this->value | rhs.value}; }
+
+private:
+    explicit OutputLevels(unsigned int value) : value{value} { }
+    static unsigned int toInternal(OutputLevel level) { return static_cast<unsigned int>(level); }
+
+private:
+    unsigned int value;
+};
+
+inline OutputLevels operator|(OutputLevel lhs, OutputLevel rhs)
+{
+    return OutputLevels({lhs, rhs});
+}
+
+inline OutputLevels operator|(OutputLevels lhs, OutputLevel rhs)
+{
+    lhs.addLevel(rhs);
+    return lhs;
+}
+
+inline OutputLevels operator|(OutputLevel lhs, OutputLevels rhs)
+{
+    return rhs | lhs;
+}
+} // namespace flounder
+
+#endif // FLOUNDER_GAME_OUTPUT_LEVELS_H

--- a/src/output/output_manager.h
+++ b/src/output/output_manager.h
@@ -1,0 +1,106 @@
+#ifndef FLOUNDER_GAME_OUTPUT_MANAGER_H
+#define FLOUNDER_GAME_OUTPUT_MANAGER_H
+
+#include "output.h"
+#include "output_levels.h"
+
+#include <vector>
+
+namespace flounder
+{
+class OutputManager
+{
+    std::vector<std::pair<std::unique_ptr<Output>, OutputLevels>> outputs;
+
+public:
+    OutputManager() = default;
+    void addOutput(
+     std::unique_ptr<Output> output, OutputLevels levels = OutputLevels{OutputLevel::all})
+    {
+        outputs.push_back({std::move(output), levels});
+    }
+
+    template<typename... Args>
+    void user(const std::string& format_string, Args&&... args)
+    {
+        output(format(format_string, std::forward<Args...>(args...)), OutputLevel::user);
+    }
+    template<typename... Args>
+    void fatal(const std::string& format_string, Args&&... args)
+    {
+        output(format(format_string, std::forward<Args...>(args...)), OutputLevel::fatal);
+    }
+    template<typename... Args>
+    void error(const std::string& format_string, Args&&... args)
+    {
+        output(format(format_string, std::forward<Args...>(args...)), OutputLevel::error);
+    }
+    template<typename... Args>
+    void warning(const std::string& format_string, Args&&... args)
+    {
+        output(format(format_string, std::forward<Args...>(args...)), OutputLevel::warning);
+    }
+    template<typename... Args>
+    void notice(const std::string& format_string, Args&&... args)
+    {
+        output(format(format_string, std::forward<Args...>(args...)), OutputLevel::notice);
+    }
+    template<typename... Args>
+    void info(const std::string& format_string, Args&&... args)
+    {
+        output(format(format_string, std::forward<Args...>(args...)), OutputLevel::info);
+    }
+    template<typename... Args>
+    void debug(const std::string& format_string, Args&&... args)
+    {
+        output(format(format_string, std::forward<Args...>(args...)), OutputLevel::debug);
+    }
+
+    template<typename Argument>
+    OutputManager& operator<<(Argument&& argument)
+    {
+        output(argument, current_level);
+        return *this;
+    }
+
+    OutputManager& operator<<(OutputLevel level)
+    {
+        this->current_level = level;
+
+        forEachOutput([level](Output& output, OutputLevels /*level_filter*/) { output << level; });
+        return *this;
+    }
+
+protected:
+    template<typename... Args>
+    std::string format(const std::string& format_string, Args&&... args)
+    {
+        return fmt::vformat(format_string, fmt::basic_format_args(std::forward<Args...>(args...)));
+    }
+
+    template<typename Argument>
+    void output(Argument&& argument, OutputLevel level)
+    {
+        forEachOutput(
+         [level, &argument](Output& output, OutputLevels level_filter)
+         {
+             if(level_filter.hasLevel(level))
+                 output << argument;
+         });
+    }
+
+    template<typename Func>
+    void forEachOutput(Func&& function)
+    {
+        for(const auto& [output, level_filter] : outputs)
+        {
+            function(*output, level_filter);
+        }
+    }
+
+private:
+    OutputLevel current_level = OutputLevel::none;
+};
+} // namespace flounder
+
+#endif // FLOUNDER_GAME_OUTPUT_MANAGER_H


### PR DESCRIPTION
This pull request introduces:

- dependency to `fmt` library (until `std::format` support is more common)
- output manager to provide a uniform interface for program output
- output to `std::cout`, `std::cerr` and a file