### PR TITLE
Add command line argument parsing

### DIFF
--- a/.github/workflows/cpp-lint.yml
+++ b/.github/workflows/cpp-lint.yml
@@ -14,6 +14,7 @@ jobs:
             sudo apt-get -y --no-install-recommends install \
               cmake='3.22.*' \
               clang-tidy='1:14.*' \
+              libboost-program-options-dev='1.74.*' \
               libfmt-dev='8.*'
       - name: Generate compile_commands.json
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_CXX_FLAGS
-    "-fsanitize=undefined -pthread -ffast-math -Wall -Wextra -Wno-psabi -pedantic-errors"
-)
+    "-pthread -ffast-math -Wall -Wextra -Wno-psabi -pedantic-errors -Werror")
 set(CMAKE_CXX_FLAGS_DEBUG "${DEBUG_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${OPTIMIZE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${DEBUG_FLAGS} ${OPTIMIZE_FLAGS}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
+find_package(Boost 1.68.0 REQUIRED COMPONENTS program_options)
 find_package(fmt 8.1.0 REQUIRED)
 
 set(TARGET_NAME "flounder_game")
 
 add_executable(${TARGET_NAME} main.cpp)
-target_link_libraries(${TARGET_NAME} PRIVATE fmt::fmt)
+target_link_libraries(${TARGET_NAME} PRIVATE fmt::fmt Boost::program_options)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,5 +3,6 @@ find_package(fmt 8.1.0 REQUIRED)
 
 set(TARGET_NAME "flounder_game")
 
-add_executable(${TARGET_NAME} main.cpp)
+add_executable(${TARGET_NAME} main.cpp command_line/command_line_options.cpp
+                              command_line/command_line_parser.cpp)
 target_link_libraries(${TARGET_NAME} PRIVATE fmt::fmt Boost::program_options)

--- a/src/command_line/command_line_options.cpp
+++ b/src/command_line/command_line_options.cpp
@@ -1,0 +1,44 @@
+#include "command_line_options.h"
+
+#include <boost/program_options.hpp>
+
+namespace flounder
+{
+CommandLineOptions::CommandLineOptions(std::shared_ptr<OutputManager> output) :
+ CommandLineOptions{"", std::move(output)}
+{
+}
+
+CommandLineOptions::CommandLineOptions(
+ std::string program_invocation_name, std::shared_ptr<OutputManager> output) :
+ program_invocation_name{std::move(program_invocation_name)},
+ output{std::move(output)}
+{
+    if(!this->output)
+        this->output = std::make_shared<OutputManager>();
+}
+
+void CommandLineOptions::setOptions(CommandLineOptions::ArgumentsMap new_general_arguments,
+ std::string subcommand, CommandLineOptions::ArgumentsMap new_subcommand_arguments)
+{
+    this->parsed_general_arguments = std::move(new_general_arguments);
+    this->parsed_subcommand = std::move(subcommand);
+    this->parsed_subcommand_arguments = std::move(new_subcommand_arguments);
+}
+
+[[nodiscard]] CommandLineOptions::OptionsDescription CommandLineOptions::generalOptions()
+{
+    OptionsDescription general_options("General options");
+    general_options.add_options()("version", boost::program_options::bool_switch(), "");
+    return general_options;
+}
+
+[[nodiscard]] std::map<std::string, CommandLineOptions::OptionsDescription>
+ CommandLineOptions::subcommandsOptions()
+{
+    OptionsDescription info_options("info options");
+    info_options.add_options()(
+     "verbose,v", boost::program_options::bool_switch(), "Increase verbosity of output");
+    return {{"info", info_options}};
+}
+} // namespace flounder

--- a/src/command_line/command_line_options.h
+++ b/src/command_line/command_line_options.h
@@ -1,0 +1,47 @@
+#ifndef FLOUNDER_GAME_COMMAND_LINE_OPTIONS_H
+#define FLOUNDER_GAME_COMMAND_LINE_OPTIONS_H
+
+#include "output/output_manager.h"
+
+#include <string>
+#include <vector>
+
+#include <boost/program_options.hpp>
+
+namespace flounder
+{
+class CommandLineOptions
+{
+public:
+    using OptionsDescription = boost::program_options::options_description;
+    using ArgumentsMap = boost::program_options::variables_map;
+
+public:
+    explicit CommandLineOptions(std::shared_ptr<OutputManager> output = nullptr);
+    explicit CommandLineOptions(
+     std::string program_invocation_name, std::shared_ptr<OutputManager> output = nullptr);
+
+    void setOptions(ArgumentsMap new_general_arguments = {}, std::string subcommand = "",
+     ArgumentsMap new_subcommand_arguments = {});
+
+    [[nodiscard]] const auto& generalArguments() const { return parsed_general_arguments; }
+    [[nodiscard]] const auto& subcommand() const { return parsed_subcommand; }
+    [[nodiscard]] const auto& subcommandArguments() const { return parsed_subcommand_arguments; }
+
+    [[nodiscard]] static OptionsDescription generalOptions();
+    [[nodiscard]] static std::map<std::string, OptionsDescription> subcommandsOptions();
+
+private:
+    std::string program_invocation_name;
+    std::string program_description;
+    std::vector<std::string> command_line_arguments;
+
+    ArgumentsMap parsed_general_arguments;
+    std::string parsed_subcommand;
+    ArgumentsMap parsed_subcommand_arguments;
+
+    std::shared_ptr<OutputManager> output;
+};
+} // namespace flounder
+
+#endif // FLOUNDER_GAME_COMMAND_LINE_OPTIONS_H

--- a/src/command_line/command_line_parser.cpp
+++ b/src/command_line/command_line_parser.cpp
@@ -17,6 +17,7 @@ CommandLineParser::CommandLineParser(std::string program_description,
         this->output = std::make_shared<OutputManager>();
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 CommandLineOptions CommandLineParser::parse(int argc, const char* const argv[])
 {
     return parse({argv, argv + argc});

--- a/src/command_line/command_line_parser.cpp
+++ b/src/command_line/command_line_parser.cpp
@@ -1,0 +1,188 @@
+#include "command_line_parser.h"
+#include "utils/utils.h"
+
+#include <boost/program_options.hpp>
+
+namespace flounder
+{
+CommandLineParser::CommandLineParser(std::string program_description,
+ CommandLineParser::OptionsDescription general_options,
+ std::map<std::string, CommandLineParser::OptionsDescription> subcommands_options,
+ std::shared_ptr<OutputManager> output) :
+ program_description{std::move(program_description)},
+ general_options{std::move(general_options)},
+ subcommands_options{std::move(subcommands_options)}, output{std::move(output)}
+{
+    if(!this->output)
+        this->output = std::make_shared<OutputManager>();
+}
+
+CommandLineOptions CommandLineParser::parse(int argc, const char* const argv[])
+{
+    return parse({argv, argv + argc});
+}
+
+CommandLineOptions CommandLineParser::parse(std::vector<std::string> args)
+{
+    if(args.empty())
+        throw std::runtime_error(
+         "Arguments can't be empty (at least the program invocation name is required)!");
+
+    auto program_invocation_name = args.front();
+    args.erase(args.begin());
+
+    CommandLineOptions parse_result{program_invocation_name, output};
+
+    auto general_parse_result = parseGeneralArguments(args);
+    boost::program_options::notify(general_parse_result.generalArguments);
+
+    if(hasSubcommand())
+    {
+        auto subcommand_parse_result = parseSubcommandArguments(general_parse_result);
+        boost::program_options::notify(subcommand_parse_result.subcommandArguments);
+
+        parse_result.setOptions(general_parse_result.generalArguments,
+         subcommand_parse_result.subcommand, subcommand_parse_result.subcommandArguments);
+    }
+    else
+    {
+        parse_result.setOptions(general_parse_result.generalArguments);
+    }
+    return parse_result;
+}
+
+// return value are the unprocessed args;
+// these will contain the subcommand with its options and any unrecognized general option
+CommandLineParser::GeneralParseResult CommandLineParser::parseGeneralArguments(
+ const std::vector<std::string>& command_line_arguments)
+{
+    GeneralParseResult general_parse_result;
+    // use the first positional argument as subcommand and all following as its options
+    boost::program_options::positional_options_description subcommand_with_unparsed_options;
+    // create copy and add subcommand if necessary to hide these internal options in help text
+    auto general_options_with_subcommand = general_options;
+    if(hasSubcommand())
+    {
+        general_options_with_subcommand.add_options()("subcommand",
+         boost::program_options::value<std::string>(),
+         "Subcommand to execute")("subcommand_options",
+         boost::program_options::value<std::vector<std::string>>(), "Options for subcommand");
+
+        subcommand_with_unparsed_options.add("subcommand", 1).add("subcommand_options", -1);
+    }
+    // parse general options and subcommand
+    try
+    {
+        auto parser = boost::program_options::command_line_parser(command_line_arguments)
+                       .options(general_options_with_subcommand)
+                       .positional(subcommand_with_unparsed_options);
+        if(hasSubcommand())
+        {
+            parser.allow_unregistered();
+        }
+        auto parsed = parser.run();
+
+        boost::program_options::store(parsed, general_parse_result.generalArguments);
+
+        // collect unrecognized options for subcommand option parsing;
+        // this will include the subcommand and any invalid general option
+        general_parse_result.unprocessedArguments = boost::program_options::collect_unrecognized(
+         parsed.options, boost::program_options::include_positional);
+    }
+    catch(const boost::program_options::error& exception)
+    {
+        *this->output << OutputLevel::error
+                      << "Error while parsing general options: " << exception.what() << '\n';
+        helpAndQuit(ExitCode::invalidArguments);
+    }
+
+    return general_parse_result;
+}
+
+// use subcommands_options to parse the corresponding options of the given subcommand
+CommandLineParser::SubcommandParseResult CommandLineParser::parseSubcommandArguments(
+ const CommandLineParser::GeneralParseResult& general_parse_result)
+{
+    CommandLineParser::SubcommandParseResult subcommand_parse_result;
+    subcommand_parse_result.subcommand = retrieveSubcommand(general_parse_result);
+    try
+    {
+        auto parsed = boost::program_options::command_line_parser(
+         general_parse_result.unprocessedArguments)
+                       .options(subcommands_options.at(subcommand_parse_result.subcommand))
+                       .run();
+
+        boost::program_options::store(parsed, subcommand_parse_result.subcommandArguments);
+    }
+    catch(const boost::program_options::error& exception)
+    {
+        *this->output << OutputLevel::error
+                      << "Error while parsing subcommand options: " << exception.what() << '\n';
+        helpAndQuit(ExitCode::invalidArguments);
+    }
+    catch(const std::out_of_range& exception)
+    {
+        // in case subcommand can not be found
+    }
+    return subcommand_parse_result;
+}
+
+std::string CommandLineParser::retrieveSubcommand(
+ const CommandLineParser::GeneralParseResult& general_parse_result)
+{
+    std::string subcommand;
+    try
+    {
+        auto subcommand_entry = general_parse_result.generalArguments["subcommand"];
+        if(!subcommand_entry.empty())
+        {
+            subcommand = subcommand_entry.as<std::string>();
+            if(subcommands_options.find(subcommand) == subcommands_options.end())
+            {
+                throw std::runtime_error("Unknown subcommand: " + subcommand);
+            }
+        }
+    }
+    catch(const boost::bad_any_cast& exception)
+    {
+        *this->output << "Error while parsing subcommand: " << exception.what() << '\n';
+        utils::quit(ExitCode::invalidArguments);
+    }
+    catch(const std::exception& exception)
+    {
+        *this->output << OutputLevel::error << exception.what() << '\n';
+        utils::quit(ExitCode::invalidArguments);
+    }
+    return subcommand;
+}
+
+[[noreturn]] void CommandLineParser::helpAndQuit(ExitCode exit_code) const
+{
+    printHelp();
+    utils::quit(exit_code);
+}
+
+void CommandLineParser::printHelp() const
+{
+    if(!program_description.empty())
+    {
+        *this->output << OutputLevel::user << program_description << '\n';
+    }
+    if(hasSubcommand())
+    {
+        *this->output << OutputLevel::user
+                      << "Usage: program [general_options] [subcommand] [subcommand_options]\n\n";
+    }
+    else
+    {
+        *this->output << OutputLevel::user << "Usage: program [options]\n\n";
+    }
+
+    *this->output << general_options << '\n';
+
+    for(const auto& subcommand_options : subcommands_options)
+    {
+        *this->output << OutputLevel::user << subcommand_options.second << '\n';
+    }
+}
+} // namespace flounder

--- a/src/command_line/command_line_parser.h
+++ b/src/command_line/command_line_parser.h
@@ -1,0 +1,67 @@
+#ifndef FLOUNDER_GAME_COMMAND_LINE_PARSER_H
+#define FLOUNDER_GAME_COMMAND_LINE_PARSER_H
+
+#include "command_line_options.h"
+#include "output/output_manager.h"
+#include "utils/constants.h"
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <boost/program_options.hpp>
+
+namespace flounder
+{
+class CommandLineParser
+{
+public:
+    using OptionsDescription = boost::program_options::options_description;
+    using ArgumentsMap = boost::program_options::variables_map;
+
+public:
+    CommandLineParser(std::string program_description, OptionsDescription general_options,
+     std::map<std::string, OptionsDescription> subcommands_options,
+     std::shared_ptr<OutputManager> output = nullptr);
+
+    CommandLineOptions parse(int argc, const char* const argv[]);
+    CommandLineOptions parse(std::vector<std::string> args);
+
+protected:
+    [[nodiscard]] bool hasSubcommand() const { return !subcommands_options.empty(); }
+
+    struct GeneralParseResult
+    {
+        /// Includes the general arguments and a key for the subcommand
+        ArgumentsMap generalArguments;
+        /// Includes all arguments that were not a general argument or a subcommand
+        std::vector<std::string> unprocessedArguments;
+    };
+    struct SubcommandParseResult
+    {
+        std::string subcommand;
+        ArgumentsMap subcommandArguments;
+    };
+    GeneralParseResult parseGeneralArguments(
+     const std::vector<std::string>& all_command_line_arguments);
+    SubcommandParseResult parseSubcommandArguments(const GeneralParseResult& general_parse_result);
+    /// Retrieve subcommand from given parse result
+    ///
+    /// @return The valid subcommand or an empty string if no subcommand was found
+    ///
+    /// @throw If subcommand is invalid
+    std::string retrieveSubcommand(const GeneralParseResult& general_parse_result);
+
+    void printHelp() const;
+    [[noreturn]] void helpAndQuit(ExitCode exit_code) const;
+
+private:
+    std::string program_description;
+    OptionsDescription general_options;
+    std::map<std::string, OptionsDescription> subcommands_options;
+
+    std::shared_ptr<OutputManager> output;
+};
+} // namespace flounder
+
+#endif // FLOUNDER_GAME_COMMAND_LINE_PARSER_H

--- a/src/command_line/command_line_parser.h
+++ b/src/command_line/command_line_parser.h
@@ -24,6 +24,7 @@ public:
      std::map<std::string, OptionsDescription> subcommands_options,
      std::shared_ptr<OutputManager> output = nullptr);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
     CommandLineOptions parse(int argc, const char* const argv[]);
     CommandLineOptions parse(std::vector<std::string> args);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,8 @@
-#include "output/output_manager.h"
+#include "command_line/command_line_parser.h"
 #include "output/cerr_output.h"
 #include "output/cout_output.h"
 #include "output/file_output.h"
+#include "output/output_manager.h"
 
 #include <chrono>
 #include <iostream>
@@ -22,4 +23,9 @@ std::shared_ptr<flounder::OutputManager> createOutputManager()
 int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
 {
     auto output = createOutputManager();
+
+    auto parser = flounder::CommandLineParser("Flounders are fish.",
+     flounder::CommandLineOptions::generalOptions(),
+     flounder::CommandLineOptions::subcommandsOptions(), output);
+    auto command_line_arguments = parser.parse(argc, argv);
 }

--- a/src/utils/constants.h
+++ b/src/utils/constants.h
@@ -1,0 +1,14 @@
+#ifndef FLOUNDER_GAME_CONSTANTS_H
+#define FLOUNDER_GAME_CONSTANTS_H
+
+namespace flounder
+{
+enum class ExitCode
+{
+    success = 0,
+    error = 1,
+    invalidArguments = 2,
+};
+} // namespace flounder
+
+#endif // FLOUNDER_GAME_CONSTANTS_H

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -1,0 +1,20 @@
+#ifndef FLOUNDER_GAME_UTILS_H
+#define FLOUNDER_GAME_UTILS_H
+
+#include "constants.h"
+
+#include <cstdlib>
+#include <mutex>
+
+namespace flounder::utils
+{
+[[noreturn]] inline void quit(ExitCode exit_code)
+{
+    static std::mutex exit_mutex;
+    std::unique_lock<std::mutex> const exit_lock{exit_mutex};
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    std::exit(static_cast<int>(exit_code));
+}
+} // namespace flounder::utils
+
+#endif // FLOUNDER_GAME_UTILS_H


### PR DESCRIPTION
This merge request introduces the basic logic for argument parsing.

- It adds a dependency to `boost::program_options`.
- Command line parsing features:
  - General option parsing
  - Subcommand parsing
  - Subcommand option parsing
  - Help message
- `quit` function and `ExitCode` enum with basic exit codes