### PR TITLE
Setup unit tests

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,6 +24,7 @@ AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: 'true'
 BinPackParameters: 'true'
 BreakBeforeBraces: Custom
+BreakBeforeConceptDeclarationsStyle: Always
 BraceWrapping:
   AfterCaseLabel: true
   AfterClass: true
@@ -67,6 +68,7 @@ MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 PointerAlignment: Left
 ReflowComments: 'false'
+RequiresExpressionIndentation: OuterScope
 SortIncludes: 'false'
 SortUsingDeclarations: 'false'
 SpaceAfterCStyleCast: 'false'

--- a/.github/workflows/cpp-unittest.yml
+++ b/.github/workflows/cpp-unittest.yml
@@ -1,0 +1,38 @@
+name: "C++ Unittest"
+
+on: [push, pull_request]
+
+jobs:
+  unittest:
+    name: "unit tests"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+            sudo apt-get update -y
+            sudo apt-get -y --no-install-recommends install \
+              cmake='3.22.*' \
+              gcc-11='11.*' \
+              libboost-program-options-dev='1.74.*' \
+              libfmt-dev='8.*' \
+              libgmock-dev='1.*' \
+              libgtest-dev='1.*'
+      - name: Execute cmake
+        run: |
+          mkdir -pv build
+          cd build
+          cmake -DENABLE_TESTS=ON \
+            -DENABLE_COVERAGE=ON \
+            -DENABLE_ADDRESS_SANITIZE=ON \
+            -DENABLE_UNDEFINED_SANITIZE=ON \
+            -DENABLE_UNREACHABLE_SANITIZE=ON \
+            ..
+      - name: Execute make
+        run: |
+          cd build
+          make -j
+      - name: Execute tests
+        run: |
+          cd build/test
+          ./tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 
 project(flounder_game)
 
+option(ENABLE_TESTS "Enable compilation of tests" OFF)
+
 find_package(Boost 1.68.0 REQUIRED COMPONENTS program_options)
 find_package(fmt 8.1.0 REQUIRED)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -39,3 +41,7 @@ set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os")
 message(STATUS "Compiling in ${CMAKE_BUILD_TYPE} mode")
 
 add_subdirectory(src)
+
+if(${ENABLE_TESTS})
+  add_subdirectory(test)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 project(flounder_game)
 
 option(ENABLE_TESTS "Enable compilation of tests" OFF)
+option(ENABLE_COVERAGE "Enable compilation with test coverage flags" OFF)
 
 find_package(Boost 1.68.0 REQUIRED COMPONENTS program_options)
 find_package(fmt 8.1.0 REQUIRED)
@@ -37,6 +38,15 @@ set(CMAKE_CXX_FLAGS_DEBUG "${DEBUG_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${OPTIMIZE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${DEBUG_FLAGS} ${OPTIMIZE_FLAGS}")
 set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os")
+
+if(${ENABLE_COVERAGE})
+  set(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
+  set(CMAKE_SHARED_LINKER_FLAGS
+      "${CMAKE_SHARED_LINKER_FLAGS} -lgcov -fprofile-arcs -ftest-coverage")
+  set(CMAKE_EXE_LINKER_FLAGS
+      "${CMAKE_EXE_LINKER_FLAGS} -lgcov -fprofile-arcs -ftest-coverage")
+endif()
 
 message(STATUS "Compiling in ${CMAKE_BUILD_TYPE} mode")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,18 @@ cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 
 project(flounder_game)
 
+find_package(Boost 1.68.0 REQUIRED COMPONENTS program_options)
+find_package(fmt 8.1.0 REQUIRED)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 # if not specified otherwise, build in release mode
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
+
+set(EXECUTABLE_NAME "flounder_game")
+set(LIBRARY_NAME "flounder")
 
 # enable generation of compile_commands.json file
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@ project(flounder_game)
 
 option(ENABLE_TESTS "Enable compilation of tests" OFF)
 option(ENABLE_COVERAGE "Enable compilation with test coverage flags" OFF)
+option(ENABLE_ADDRESS_SANITIZE "Enable compilation with address sanitize flags"
+       OFF)
+option(ENABLE_THREAD_SANITIZE "Enable compilation with thread sanitize flags"
+       OFF)
+option(ENABLE_UNDEFINED_SANITIZE
+       "Enable compilation with undefined sanitize flags" OFF)
+option(ENABLE_UNREACHABLE_SANITIZE
+       "Enable compilation with unreachable sanitize flags" OFF)
 
 find_package(Boost 1.68.0 REQUIRED COMPONENTS program_options)
 find_package(fmt 8.1.0 REQUIRED)
@@ -46,6 +54,19 @@ if(${ENABLE_COVERAGE})
       "${CMAKE_SHARED_LINKER_FLAGS} -lgcov -fprofile-arcs -ftest-coverage")
   set(CMAKE_EXE_LINKER_FLAGS
       "${CMAKE_EXE_LINKER_FLAGS} -lgcov -fprofile-arcs -ftest-coverage")
+endif()
+
+if(${ENABLE_ADDRESS_SANITIZE})
+  set(CMAKE_CXX_FLAGS "-fsanitize=address ${CMAKE_CXX_FLAGS}")
+endif()
+if(${ENABLE_THREAD_SANITIZE})
+  set(CMAKE_CXX_FLAGS "-fsanitize=thread ${CMAKE_CXX_FLAGS}")
+endif()
+if(${ENABLE_UNDEFINED_SANITIZE})
+  set(CMAKE_CXX_FLAGS "-fsanitize=undefined ${CMAKE_CXX_FLAGS}")
+endif()
+if(${ENABLE_UNREACHABLE_SANITIZE})
+  set(CMAKE_CXX_FLAGS "-fsanitize=unreachable ${CMAKE_CXX_FLAGS}")
 endif()
 
 message(STATUS "Compiling in ${CMAKE_BUILD_TYPE} mode")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,6 @@
-find_package(Boost 1.68.0 REQUIRED COMPONENTS program_options)
-find_package(fmt 8.1.0 REQUIRED)
+add_library(${LIBRARY_NAME} command_line/command_line_options.cpp
+                            command_line/command_line_parser.cpp)
+target_link_libraries(${LIBRARY_NAME} fmt::fmt Boost::program_options Threads::Threads)
 
-set(TARGET_NAME "flounder_game")
-
-add_executable(${TARGET_NAME} main.cpp command_line/command_line_options.cpp
-                              command_line/command_line_parser.cpp)
-target_link_libraries(${TARGET_NAME} PRIVATE fmt::fmt Boost::program_options)
+add_executable(${EXECUTABLE_NAME} main.cpp)
+target_link_libraries(${EXECUTABLE_NAME} PRIVATE Threads::Threads ${LIBRARY_NAME})

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -29,7 +29,9 @@ public:
     BaseOutput(BaseOutput&&) noexcept = default;
     BaseOutput& operator=(const BaseOutput&) = default;
     BaseOutput& operator=(BaseOutput&&) noexcept = default;
-    virtual StreamType& stream() = 0;
+
+    using Stream = StreamType;
+    virtual Stream& stream() = 0;
 
     template<typename Argument>
     BaseOutput& operator<<(Argument&& argument)

--- a/src/utils/concepts.h
+++ b/src/utils/concepts.h
@@ -1,0 +1,36 @@
+#ifndef FLOUNDER_GAME_CONCEPTS_H
+#define FLOUNDER_GAME_CONCEPTS_H
+
+#include <string>
+#include <type_traits>
+
+namespace flounder {
+template <typename T>
+concept is_integer = std::is_integral_v<T>;
+
+template <typename T>
+concept is_floating_point = std::is_floating_point_v<T>;
+
+template <typename T>
+concept is_string = std::is_same_v<T, std::string>;
+
+template <typename T>
+concept is_boolean = std::is_same_v<T, bool>;
+
+template <typename T>
+concept is_const = std::is_const_v<T>;
+
+template <typename T>
+concept is_mutable = !
+std::is_const_v<T>;
+
+template <typename T>
+concept is_container = requires(T container, const T const_container) {
+                         { const_container.begin() } -> std::forward_iterator;
+                         { const_container.end() } -> std::forward_iterator;
+                         { container.begin() } -> std::forward_iterator;
+                         { container.end() } -> std::forward_iterator;
+                       };
+} // namespace flounder
+
+#endif // FLOUNDER_GAME_CONCEPTS_H

--- a/src/utils/flags.h
+++ b/src/utils/flags.h
@@ -1,0 +1,63 @@
+#ifndef FLOUNDER_GAME_FLAGS_H
+#define FLOUNDER_GAME_FLAGS_H
+
+#include <initializer_list>
+
+namespace flounder
+{
+template<typename FlagEnum, typename InternalType = unsigned int>
+class Flags
+{
+public:
+    constexpr Flags() : value{0} { }
+    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+    explicit(false) constexpr Flags(FlagEnum flag) : Flags{{flag}} { }
+    constexpr Flags(std::initializer_list<FlagEnum> flags) : value{0x00}
+    {
+        for(auto flag : flags)
+            this->add(flag);
+    }
+
+    constexpr void add(FlagEnum flag) { this->value |= toInternal(flag); }
+    constexpr void remove(FlagEnum flag) { this->value &= ~toInternal(flag); }
+
+    [[nodiscard]] constexpr bool has(FlagEnum flag) const
+    {
+        return (this->value & toInternal(flag)) != 0x00;
+    }
+    [[nodiscard]] constexpr bool operator&(FlagEnum flag) const { return has(flag); }
+
+    constexpr Flags operator|(Flags rhs) const { return Flags{this->value | rhs.value}; }
+    constexpr Flags operator|(FlagEnum rhs) const { return *this | Flags{rhs}; }
+    constexpr Flags& operator|=(Flags rhs)
+    {
+        add(rhs);
+        return *this;
+    }
+    constexpr Flags& operator|=(FlagEnum rhs) { return *this |= Flags{rhs}; }
+
+protected:
+    explicit constexpr Flags(InternalType value) : value{value} { }
+    static constexpr InternalType toInternal(FlagEnum level)
+    {
+        return static_cast<InternalType>(level);
+    }
+
+private:
+    InternalType value;
+};
+
+template<typename FlagEnum>
+inline Flags<FlagEnum> operator|(FlagEnum lhs, FlagEnum rhs)
+{
+    return Flags<FlagEnum>({lhs, rhs});
+}
+
+template<typename FlagEnum>
+inline Flags<FlagEnum> operator|(FlagEnum lhs, Flags<FlagEnum> rhs)
+{
+    return rhs | lhs;
+}
+} // namespace flounder
+
+#endif // FLOUNDER_GAME_FLAGS_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+find_package(GTest REQUIRED)
+
+include_directories(../ ../src)
+
+add_executable(tests output_tests.cpp command_line_tests.cpp)
+
+target_link_libraries(tests PRIVATE GTest::GTest GTest::Main gmock fmt::fmt
+                                    Boost::program_options Threads::Threads ${LIBRARY_NAME})

--- a/test/command_line_tests.cpp
+++ b/test/command_line_tests.cpp
@@ -1,0 +1,61 @@
+#include "command_line/command_line_parser.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <exception>
+#include <memory>
+#include <string>
+#include <thread>
+
+class CommandLineParserTest : public testing::Test {
+protected:
+  void SetUp() override {
+    try {
+    } catch (const std::exception &exception) {
+      FAIL() << "Failed to execute SetUp: " << exception.what();
+    }
+  }
+
+  void TearDown() override {}
+
+protected:
+  static constexpr std::string_view TEST_INVOCATION_NAME = "invocation_name";
+  static flounder::CommandLineParser::OptionsDescription
+  testOptionsDescription() {
+    flounder::CommandLineParser::OptionsDescription options;
+    options.add_options()("abc,a", "ABC");
+    return options;
+  }
+};
+
+TEST_F(CommandLineParserTest, emptyOptionsAndArguments) {
+  flounder::CommandLineParser test_parser(
+      "", flounder::CommandLineParser::OptionsDescription(), {}, nullptr);
+  EXPECT_THROW(test_parser.parse({}), std::runtime_error);
+}
+
+TEST_F(CommandLineParserTest, onlyInvocationName) {
+  flounder::CommandLineParser test_parser(
+      "", flounder::CommandLineParser::OptionsDescription(), {}, nullptr);
+  EXPECT_NO_THROW(test_parser.parse({std::string{TEST_INVOCATION_NAME}}));
+}
+
+TEST_F(CommandLineParserTest, testUnknownArgument) {
+  flounder::CommandLineParser test_parser(
+      "", flounder::CommandLineParser::OptionsDescription(), {}, nullptr);
+  EXPECT_EXIT(test_parser.parse({"invocation_name", "-x"}),
+              testing::ExitedWithCode(
+                  static_cast<int>(flounder::ExitCode::invalidArguments)),
+              testing::HasSubstr("Error"));
+}
+
+TEST_F(CommandLineParserTest, testValidArguments) {
+  auto test_options_description = testOptionsDescription();
+  auto test_argument_name =
+      test_options_description.options().front()->long_name();
+  flounder::CommandLineParser test_parser("", test_options_description, {},
+                                          nullptr);
+  EXPECT_NO_THROW(test_parser.parse({"invocation_name", "--abc"}));
+}

--- a/test/helpers/random.h
+++ b/test/helpers/random.h
@@ -1,0 +1,151 @@
+#ifndef FLOUNDER_GAME_TEST_HELPERS_RANDOM_H
+#define FLOUNDER_GAME_TEST_HELPERS_RANDOM_H
+
+#include "utils/concepts.h"
+#include "utils/flags.h"
+
+#include <algorithm>
+#include <concepts>
+#include <random>
+#include <string>
+#include <string_view>
+
+constexpr unsigned int AUTO_SEED = 0x1234;
+template <typename Distribution, unsigned int seed = AUTO_SEED> class Random {
+public:
+  explicit constexpr Random(Distribution &&dist)
+      : random_generator{seed}, dist{dist} {}
+
+  constexpr void reset() { random_generator.seed(seed); }
+
+  constexpr auto operator()() { return dist(random_generator); }
+
+  constexpr auto &generator() { return random_generator; }
+
+private:
+  std::mt19937_64 random_generator;
+  Distribution dist;
+};
+
+// random bool generation
+
+template <typename T>
+  requires std::same_as<T, bool>
+inline T randomValue() {
+  return Random(std::uniform_int_distribution(0, 1))();
+}
+
+// random float generation
+
+template <typename T>
+  requires std::floating_point<T>
+inline T randomValue(T min, T max) {
+  return Random(std::uniform_real_distribution<T>(min, max))();
+}
+
+template <typename T>
+  requires std::floating_point<T>
+inline T randomValue() {
+  return randomValue<T>(std::numeric_limits<T>::min(),
+                        std::numeric_limits<T>::max());
+}
+
+// random int generation
+
+template <typename T>
+  requires std::integral<T> && (!std::same_as<T, bool>)
+inline T randomValue(T min, T max) {
+  return Random(std::uniform_int_distribution<T>(min, max))();
+}
+
+template <typename T>
+  requires std::integral<T> && (!std::same_as<T, bool>)
+inline T randomValue() {
+  return randomValue<T>(std::numeric_limits<T>::min(),
+                        std::numeric_limits<T>::max());
+}
+
+// random string generation
+
+enum class StringAttribute {
+  none = 0x00,
+  upperCase = 0x01,
+  lowerCase = 0x02,
+  numbers = 0x04,
+  specialCharacters = 0x08,
+  spaces = 0x10,
+  all = 0xFF,
+};
+
+using StringAttributes = flounder::Flags<StringAttribute>;
+
+template <typename T>
+  requires std::convertible_to<T, std::string>
+inline std::string randomValue(std::size_t min_length, std::size_t max_length,
+                               StringAttributes attributes) {
+  constexpr std::string_view LOWER_CHAR_SET = "abcdefghijklmnopqrstuvwxyz";
+  constexpr std::string_view UPPER_CHAR_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  constexpr std::string_view NUMBER_CHAR_SET = "1234567890";
+  constexpr std::string_view SPECIAL_CHAR_SET =
+      "!@#$%^&*()`~-_=+[{]{|;:'\",<.>/?";
+
+  std::string total_char_set;
+  if (attributes & StringAttribute::lowerCase)
+    total_char_set += LOWER_CHAR_SET;
+  if (attributes & StringAttribute::upperCase)
+    total_char_set += UPPER_CHAR_SET;
+  if (attributes & StringAttribute::numbers)
+    total_char_set += NUMBER_CHAR_SET;
+  if (attributes & StringAttribute::specialCharacters)
+    total_char_set += SPECIAL_CHAR_SET;
+  if (attributes & StringAttribute::spaces)
+    total_char_set += ' ';
+
+  std::string result;
+  std::size_t length = Random(
+      std::uniform_int_distribution<std::size_t>(min_length, max_length))();
+  auto random = Random(
+      std::uniform_int_distribution<std::size_t>(0, total_char_set.size() - 1));
+  for (std::size_t i = 0; i < length; ++i)
+    result += total_char_set.at(random());
+  return result;
+}
+
+template <typename T>
+  requires std::convertible_to<T, std::string>
+inline std::string randomValue(std::size_t min_length, std::size_t max_length) {
+  return randomValue<T>(min_length, max_length, StringAttribute::all);
+}
+
+template <typename T>
+  requires std::convertible_to<T, std::string>
+inline std::string randomValue(StringAttributes attributes) {
+  constexpr auto MAX_LENGTH = 1e6;
+  return randomValue<T>(0, MAX_LENGTH, attributes);
+}
+
+template <typename T>
+  requires std::convertible_to<T, std::string>
+inline std::string randomValue() {
+  return randomValue<T>(StringAttribute::all);
+}
+
+// random array generation
+
+template <typename T, std::size_t n, typename... Args>
+inline std::array<T, n> randomValues(Args &&...args) {
+  std::array<T, n> result;
+  for (auto &value : result)
+    value = randomValue<T>(args...);
+  return result;
+}
+
+template <typename T>
+  requires flounder::is_container<T>
+inline T randomShuffle(const T &input) {
+  T result{std::begin(input), std::end(input)};
+  std::shuffle(std::begin(result), std::end(result),
+               Random(std::uniform_int_distribution<>()).generator());
+}
+
+#endif // FLOUNDER_GAME_TEST_HELPERS_RANDOM_H

--- a/test/output_tests.cpp
+++ b/test/output_tests.cpp
@@ -1,0 +1,103 @@
+#include "helpers/random.h"
+
+#include "output/output.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <exception>
+#include <memory>
+#include <string>
+#include <thread>
+
+class OutputTest : public testing::Test
+{
+public:
+    struct StreamStub
+    {
+        template<typename T>
+        StreamStub& operator<<(T&& value)
+        {
+            capturedOutput.push_back(value);
+            return *this;
+        }
+
+        std::vector<std::any> capturedOutput;
+    };
+
+    struct TestOutput : public flounder::BaseOutput<StreamStub>
+    {
+        Stream& stream() override { return streamStub; }
+        StreamStub streamStub;
+    };
+
+protected:
+    void SetUp() override
+    {
+        try
+        {
+            // do something
+        }
+        catch(const std::exception& exception)
+        {
+            FAIL() << "Failed to execute SetUp: " << exception.what();
+        }
+    }
+
+    void TearDown() override { }
+
+protected:
+    TestOutput output;
+};
+
+template<typename T>
+class TypedOutputTest : public OutputTest
+{
+};
+
+using SingleValueTestTypes = testing::Types<std::string, int, double, char, bool>;
+TYPED_TEST_SUITE(TypedOutputTest, SingleValueTestTypes);
+TYPED_TEST(TypedOutputTest, singleValueOutput)
+{
+    TypeParam test_input{};
+    test_input = randomValue<TypeParam>();
+    this->output << test_input;
+
+    EXPECT_EQ(this->output.streamStub.capturedOutput.size(), 1);
+    TypeParam test_output;
+    EXPECT_NO_THROW(
+     { test_output = std::any_cast<TypeParam>(this->output.streamStub.capturedOutput.at(0)); });
+    EXPECT_EQ(test_output, test_input);
+}
+
+TYPED_TEST(TypedOutputTest, multiValueOutput)
+{
+    const auto test_inputs = randomValues<TypeParam, 5>();
+    this->output << test_inputs.at(0) << test_inputs.at(1) << test_inputs.at(2) << test_inputs.at(3)
+                 << test_inputs.at(4);
+    EXPECT_EQ(this->output.streamStub.capturedOutput.size(), 5);
+}
+
+TEST_F(OutputTest, mixedValueOutput)
+{
+    const auto test_input_one = randomValue<int>();
+    const auto test_input_two = randomValue<std::string>();
+    const auto test_input_three = randomValue<bool>();
+    this->output << test_input_one << test_input_two << test_input_three;
+    EXPECT_NO_THROW({
+        auto test_output = std::any_cast<decltype(test_input_one)>(
+         this->output.streamStub.capturedOutput.at(0));
+        EXPECT_EQ(test_output, test_input_one);
+    });
+    EXPECT_NO_THROW({
+        auto test_output = std::any_cast<decltype(test_input_two)>(
+         this->output.streamStub.capturedOutput.at(1));
+        EXPECT_EQ(test_output, test_input_two);
+    });
+    EXPECT_NO_THROW({
+        auto test_output = std::any_cast<decltype(test_input_three)>(
+         this->output.streamStub.capturedOutput.at(2));
+        EXPECT_EQ(test_output, test_input_three);
+    });
+}


### PR DESCRIPTION
This merge request adds the following:

- Dependency to `gtest` and `gmock`
- Introduce basic infrastructure for unit testing
  - CI for executing unit tests
  - test executable which can be enabled via cmake
  - coverage data generation via cmake switch
- Add santizer options to cmake